### PR TITLE
Add Skywalk Mescal 6 Glider Model

### DIFF
--- a/scripts/build_mescal6.py
+++ b/scripts/build_mescal6.py
@@ -68,16 +68,20 @@ if __name__ == "__main__":
         print(f"  alpha_p2b:   {np.rad2deg(alpha_p2b).round(4)}")
 
     print("\n<pausing before polar curves>\n")
-    breakpoint()
+    # breakpoint()
 
     input("Plot the polar curve?  Press any key")
     accelerating, braking = gsim.extras.compute_polars.compute_polar_data(
         paraglider,
     )
 
+    # Just
+    # gsim.extras.compute_polars.plot_wing_coefficients(paraglider)
+
     # -----------------------------------------------------------------------
     # Plot the curves
-    fig, ax = plt.subplots(2, 2)  # [[alpha_b, sink rate], [theta_b, GR]]
+    fig = plt.figure()
+    fig.suptitle('Mescal 6 {} Characteristics'.format(size))
 
     deltas_a = accelerating["delta"]
     deltas_b = braking["delta"]
@@ -87,36 +91,42 @@ if __name__ == "__main__":
     v_RM2e_b = braking["v_RM2e"]
 
     # alpha_b versus control input
-    ax[0, 0].plot(deltas_a, np.rad2deg(accelerating["alpha_b"]), "g")
-    ax[0, 0].plot(-deltas_b, np.rad2deg(braking["alpha_b"]), "r")
-    ax[0, 0].set_xlabel("Control input [%]")
-    ax[0, 0].set_ylabel("alpha_b [deg]")
-
-    # Vertical versus horizontal airspeed
-    ax[0, 1].plot(v_RM2e_a.T[0], v_RM2e_a.T[2], "g")
-    ax[0, 1].plot(v_RM2e_b.T[0], v_RM2e_b.T[2], "r")
-    ax[0, 1].set_aspect("equal")
-    ax[0, 1].set_xlim(0, 25)
-    ax[0, 1].set_ylim(0, 8)
-    ax[0, 1].invert_yaxis()
-    ax[0, 1].set_xlabel("Horizontal airspeed [m/s]")
-    ax[0, 1].set_ylabel("sink rate [m/s]")
-    ax[0, 1].grid(which="both")
-    ax[0, 1].minorticks_on()
+    alpha_b_plot = fig.add_subplot(2, 2, 1) # Upper Left
+    alpha_b_plot.plot(deltas_a, np.rad2deg(accelerating["alpha_b"]), "g")
+    alpha_b_plot.plot(-deltas_b, np.rad2deg(braking["alpha_b"]), "r")
+    alpha_b_plot.set_xlabel("Control input [%]")
+    alpha_b_plot.set_ylabel("alpha_b [deg]")
 
     # theta_b versus control input
-    ax[1, 0].plot(deltas_a, np.rad2deg(thetas_a), "g")
-    ax[1, 0].plot(-deltas_b, np.rad2deg(thetas_b), "r")
-    ax[1, 0].set_xlabel("Control input [%]")
-    ax[1, 0].set_ylabel("theta_b [deg]")
+    theta_b_plot = fig.add_subplot(2, 2, 3) # Lower Left
+    theta_b_plot.plot(deltas_a, np.rad2deg(thetas_a), "g")
+    theta_b_plot.plot(-deltas_b, np.rad2deg(thetas_b), "r")
+    theta_b_plot.set_xlabel("Control input [%]")
+    theta_b_plot.set_ylabel("theta_b [deg]")
+
+    # Vertical versus horizontal airspeed
+    polar_plot = fig.add_subplot(2, 2, 2) # Upper Right
+    polar_plot.plot(v_RM2e_a.T[0], v_RM2e_a.T[2], "g")
+    polar_plot.plot(v_RM2e_b.T[0], v_RM2e_b.T[2], "r")
+    # polar_plot.set_aspect("equal")
+    # polar_plot.set_xlim(0, 25)
+    # polar_plot.set_ylim(0, 8)
+    polar_plot.invert_yaxis()
+    polar_plot.set_xlabel("Horizontal airspeed [m/s]")
+    polar_plot.set_ylabel("sink rate [m/s]")
+    polar_plot.grid(which="both")
+    polar_plot.minorticks_on()
 
     # Glide ratio
-    ax[1, 1].plot(v_RM2e_a.T[0], accelerating["glide_ratio"], "g")
-    ax[1, 1].plot(v_RM2e_b.T[0], braking["glide_ratio"], "r")
-    ax[1, 1].set_xlim(0, 25)
-    ax[1, 1].set_xlabel("Horizontal airspeed [m/s]")
-    ax[1, 1].set_ylabel("Glide ratio")
+    glide_ratio_plot = fig.add_subplot(2, 2, 4, sharex=polar_plot) # Lower Right. Share axis with polar plot (V forward)
+    glide_ratio_plot.plot(v_RM2e_a.T[0], accelerating["glide_ratio"], "g")
+    glide_ratio_plot.plot(v_RM2e_b.T[0], braking["glide_ratio"], "r")
+    # glide_ratio_plot.set_xlim(0, 25)
+    glide_ratio_plot.set_xlabel("Horizontal airspeed [m/s]")
+    glide_ratio_plot.set_ylabel("Glide ratio")
+    glide_ratio_plot.grid()
 
+    fig.tight_layout() # Make sure graphs don't overlap
     plt.show()
 
-    breakpoint()
+    # breakpoint()

--- a/scripts/build_mescal6.py
+++ b/scripts/build_mescal6.py
@@ -1,0 +1,122 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+import pfh.glidersim as gsim
+from pfh.glidersim import orientation
+
+if __name__ == "__main__":
+    print("\n-------------------------------------------------------------\n")
+
+    use_6a = True
+    use_6a = False  # Set to False to use Paraglider9a
+
+    size = 'XS'
+
+    wing = gsim.extras.wings.skywalk_mescal_6(size=size, verbose=True)
+
+    if size == 'XS':
+        harness = gsim.paraglider_harness.Spherical(
+            mass=75, z_riser=0.5, S=0.55, CD=0.8, kappa_w=0.15
+        )
+    else:
+        raise RuntimeError(f"Invalid Mescal 6 canopy size {size}")
+
+    if use_6a:
+        paraglider = gsim.paraglider.ParagliderSystemDynamics6a(wing, harness)
+    else:
+        paraglider = gsim.paraglider.ParagliderSystemDynamics9a(wing, harness)
+
+    print("Computing the glider equilibrium state...\n")
+    eq = paraglider.equilibrium_state()
+
+    # Compute the residual acceleration at the given equilibrium state
+    q_b2e = orientation.euler_to_quaternion(eq["Theta_b2e"])
+    q_e2b = q_b2e * [1, -1, -1, -1]
+    v_RM2e = orientation.quaternion_rotate(q_e2b, eq["v_RM2e"])
+
+    if use_6a:
+        a_RM2e, alpha_b2e, _ = paraglider.accelerations(
+            v_RM2e=eq["v_RM2e"],
+            omega_b2e=[0, 0, 0],
+            g=orientation.quaternion_rotate(q_b2e, [0, 0, 9.8]),
+            reference_solution=eq["reference_solution"],
+        )
+    else:
+        a_RM2e, alpha_b2e, alpha_p2b, _ = paraglider.accelerations(
+            v_RM2e=eq["v_RM2e"],
+            omega_b2e=[0, 0, 0],
+            omega_p2e=[0, 0, 0],
+            Theta_p2b=eq["Theta_p2b"],
+            g=orientation.quaternion_rotate(q_b2e, [0, 0, 9.8]),
+            reference_solution=eq["reference_solution"],
+        )
+
+    print("Equilibrium state:")
+    print(f"  alpha_b:     {np.rad2deg(eq['alpha_b']):>6.3f} [deg]")
+    print(f"  theta_b2e:   {np.rad2deg(eq['Theta_b2e'][1]):>6.3f} [deg]")
+    if use_6a is False:
+        theta_p2e = eq["Theta_p2b"][1] + eq["Theta_b2e"][1]
+        print(f"  theta_p2e:   {np.rad2deg(theta_p2e):>6.3f} [deg]")
+    print(f"  Glide angle: {np.rad2deg(eq['gamma_b']):>6.3f} [deg]")
+    print(f"  Glide ratio: {eq['glide_ratio']:>6.3f}")
+    print(f"  Glide speed: {np.linalg.norm(v_RM2e):>6.3f}")
+    print()
+    print("Verify accelerations at equilibrium:")
+    print(f"  a_RM2e:      {a_RM2e.round(4)}")
+    print(f"  alpha_b2e:   {np.rad2deg(alpha_b2e).round(4)}")
+    if use_6a is False:
+        print(f"  alpha_p2b:   {np.rad2deg(alpha_p2b).round(4)}")
+
+    print("\n<pausing before polar curves>\n")
+    breakpoint()
+
+    input("Plot the polar curve?  Press any key")
+    accelerating, braking = gsim.extras.compute_polars.compute_polar_data(
+        paraglider,
+    )
+
+    # -----------------------------------------------------------------------
+    # Plot the curves
+    fig, ax = plt.subplots(2, 2)  # [[alpha_b, sink rate], [theta_b, GR]]
+
+    deltas_a = accelerating["delta"]
+    deltas_b = braking["delta"]
+    thetas_a = accelerating["theta_b"]
+    thetas_b = braking["theta_b"]
+    v_RM2e_a = accelerating["v_RM2e"]
+    v_RM2e_b = braking["v_RM2e"]
+
+    # alpha_b versus control input
+    ax[0, 0].plot(deltas_a, np.rad2deg(accelerating["alpha_b"]), "g")
+    ax[0, 0].plot(-deltas_b, np.rad2deg(braking["alpha_b"]), "r")
+    ax[0, 0].set_xlabel("Control input [%]")
+    ax[0, 0].set_ylabel("alpha_b [deg]")
+
+    # Vertical versus horizontal airspeed
+    ax[0, 1].plot(v_RM2e_a.T[0], v_RM2e_a.T[2], "g")
+    ax[0, 1].plot(v_RM2e_b.T[0], v_RM2e_b.T[2], "r")
+    ax[0, 1].set_aspect("equal")
+    ax[0, 1].set_xlim(0, 25)
+    ax[0, 1].set_ylim(0, 8)
+    ax[0, 1].invert_yaxis()
+    ax[0, 1].set_xlabel("Horizontal airspeed [m/s]")
+    ax[0, 1].set_ylabel("sink rate [m/s]")
+    ax[0, 1].grid(which="both")
+    ax[0, 1].minorticks_on()
+
+    # theta_b versus control input
+    ax[1, 0].plot(deltas_a, np.rad2deg(thetas_a), "g")
+    ax[1, 0].plot(-deltas_b, np.rad2deg(thetas_b), "r")
+    ax[1, 0].set_xlabel("Control input [%]")
+    ax[1, 0].set_ylabel("theta_b [deg]")
+
+    # Glide ratio
+    ax[1, 1].plot(v_RM2e_a.T[0], accelerating["glide_ratio"], "g")
+    ax[1, 1].plot(v_RM2e_b.T[0], braking["glide_ratio"], "r")
+    ax[1, 1].set_xlim(0, 25)
+    ax[1, 1].set_xlabel("Horizontal airspeed [m/s]")
+    ax[1, 1].set_ylabel("Glide ratio")
+
+    plt.show()
+
+    breakpoint()

--- a/src/pfh/glidersim/extras/wings.py
+++ b/src/pfh/glidersim/extras/wings.py
@@ -248,3 +248,231 @@ def niviuk_hook3(
         print("Finished building the glider.\n")
 
     return wing
+
+
+
+def skywalk_mescal_6(
+    *,
+    size: str,
+    num_control_points: int = 31,
+    verbose: bool = True,
+) -> gsim.paraglider_wing.ParagliderWing:
+    """
+    Build an approximate Skywalk Mescal 6.
+
+    Parameters
+    ----------
+    size : {XS}
+        The size of the wing.
+    num_control_points : int
+        The number of aerodynamic control points.
+    verbose : bool, default: True
+        Whether to print a description of the resulting model.
+
+    References
+    ----------
+    https://skywalk.info/project/mescal/
+    """
+
+    # Specifications from the Skywalk Mescal 6 Pro Guide, p3, "Technical Data"
+    technical_specs: dict[str, dict] = {}
+
+    technical_specs['XS'] = {
+        "chord_tip": 0.66, # Min. profile depth
+        "chord_root": 2.80, # Max. profile depth
+        "chord_mean": 2.06, # Not specified
+        "S_flat": 24.29,
+        "b_flat": 10.80,
+        "AR_flat": 4.80,
+        "S": 20.48,
+        "b": 8.40,
+        "AR": 3.47,
+        "m_s": 4.6,  # Glider mass [kg]
+        "kappa_z": 6.91, # Taken from 'middle line length w.o. risers"
+        "total_line_length": 278, # Line consumption
+
+        # Helper variables
+        "number_of_cells": 38
+    }
+
+    if size not in technical_specs:
+        raise ValueError(
+            f"Invalid canopy size {size}, must be in {tuple(technical_specs.keys())}",
+        )
+
+    # Select the spec
+    specs = technical_specs[size]
+
+    if verbose:
+        print(f"Building an (approximate) Skywalk Mescal 6 {size}\n")
+
+    if verbose:
+        print("Airfoil: braking_NACA24018_Xtr0.25\n")
+    
+    airfoils = gsim.extras.airfoils.load_datfile_set("braking_NACA24018_Xtr0.25")
+    airfoil_geo = gsim.airfoil.AirfoilGeometryInterpolator(airfoils)
+    airfoil_coefs = gsim.extras.airfoils.load_polar("braking_NACA24018_Xtr0.25")
+    delta_d_max = 0.20273  # FIXME: magic number from the set of coefficients
+
+    c = gsim.foil_layout.EllipticalChord(
+        root=specs["chord_root"] / (specs["b_flat"] / 2),
+        tip=specs["chord_tip"] / (specs["b_flat"] / 2),
+    )
+
+    # Geometric torsion
+    #
+    # The distribution is uncertain. In Sec. 11.4, pg 17 of the manual ("Line
+    # Plan") it appears to have a roughly square-root spanwise distribution
+    # with a maximum value of 6 or so, but without better data I'm sticking to
+    # a linear distribution with a smaller peak (easier for the aerodynamics).
+    # theta = gsim.foil_layout.PolynomialTorsion(start=0.0, peak=6, exponent=0.5)
+    theta = gsim.foil_layout.PolynomialTorsion(start=0.05, peak=4, exponent=1)
+
+    # Using `tip_anhedral = 75` is probably more accurate, but it also
+    # increases the chances of stalling the wing tips during hard turns.
+    layout = gsim.foil_layout.FoilLayout(
+        r_x=0.70,
+        x=0,
+        r_yz=0.25,
+        yz=gsim.foil_layout.EllipticalArc(mean_anhedral=32, tip_anhedral=75),
+        c=c,
+        theta=theta,
+    )
+
+    sections = gsim.foil_sections.FoilSections(
+        profiles=airfoil_geo,
+        coefficients=airfoil_coefs,
+        intakes=gsim.foil_sections.SimpleIntakes(0.85, -0.04, -0.09),  # FIXME: guess
+        Cd_intakes=0.07,  # ref: babinsky1999AerodynamicPerformanceParagliders
+        Cd_surface=0.004,  # ref: ware1969WindtunnelInvestigationRamair
+    )
+
+    s_nodes = np.linspace(-1, 1, num_control_points + 1)
+    canopy = gsim.foil.SimpleFoil(
+        layout=layout,
+        sections=sections,
+        # b=b,  # Option 1: Scale the using the projected span
+        b_flat=specs["b_flat"],  # Option 2: Scale the using the flattened span
+        aerodynamics_method=gsim.foil_aerodynamics.Phillips,
+        aerodynamics_config={
+            "v_ref_mag": 10,
+            "alpha_ref": 5,
+            "s_nodes": s_nodes,
+            "s_clamp": s_nodes[-2],  # Mitigate fictitious stalls at wing tips
+        },
+    )
+
+    # Most of these values are based on data, but `kappa_x` is simply the
+    # choice that produces a nice polar (max and min speeds are reasonable) and
+    # the best glide ratio occurs at zero control inputs (some wings produce
+    # better glide ratios with small amounts of accelerator, but without
+    # evidence this a reasonable assumption).
+    riser_position_parameters = {
+        "kappa_x": 0.45 * specs["chord_root"],
+        # Pro guide - 3. Technical Data
+        "kappa_z": specs["kappa_z"],
+        "kappa_a": 0.13, # Maximum speed bar travel
+        # Pro guide - 11. Line Schematic
+        "kappa_A": 0.11 * specs["chord_root"],
+        "kappa_C": 0.70 * specs["chord_root"],
+    }
+
+    # TODO / Estimated from https://www.youtube.com/watch?v=D-OyGZbOmS0
+    # The `0` parameters are easy to estimate directly from small brake inputs.
+    # The "max brake" parameters are more difficult since they depend on the
+    # value of `kappa_b` (the maximum deflection supported by the model). An
+    # initial guess shows that the set of NACA 24018 coefficients is going to
+    # limit `kappa_b` to roughly 45cm; using the video to observe deflections
+    # at ~45cm (the risers are 47cm) produce `start1` and `stop1`.
+    brake_parameters = {
+        "kappa_b": 0,  # Set later with `maximize_kappa_b`
+        "s_delta_start0": 0.30,
+        "s_delta_start1": 0.08,
+        "s_delta_stop0": 0.70,
+        "s_delta_stop1": 1.05,
+    }
+
+    # Crude guesses to account for the bulk of the line drag.
+    # TODO: needs a serious review
+    line_drag_parameters = {
+        "total_line_length": specs["total_line_length"],
+        "average_line_diameter": 1e-3,  # Blind guess
+        "r_L2LE": np.array(
+            [
+                [-0.5 * specs["chord_root"], -1.75, 1.75],
+                [-0.5 * specs["chord_root"], 1.75, 1.75],
+            ],
+        ),
+        "Cd_lines": 1,  # ref: Kulhánek, 2019; page 5
+    }
+
+    lines = gsim.paraglider_wing.SimpleLineGeometry(
+        **riser_position_parameters,
+        **brake_parameters,
+        **line_drag_parameters,  # type: ignore [arg-type]
+    )
+
+    lines.maximize_kappa_b(delta_d_max, canopy.chord_length)
+
+    # Construct the wing object
+    wing = gsim.paraglider_wing.ParagliderWing(
+        lines=lines,
+        canopy=canopy,
+        rho_upper=38 / 1000,  # [kg/m^2]  Porcher Skytex 38g / Skytex Easyfly
+        rho_lower=40 / 1000,  # [kg/m^2]  Porcher Skytex Easyfly
+        rho_ribs=40 / 1000,  # [kg/m^2]  Porcher Skytex 40g hard
+        N_cells=specs["number_of_cells"]
+    )
+
+    # -----------------------------------------------------------------------
+    # Plots
+
+    # Having N+1 sections will divide the wing into N cells
+    number_of_sections = specs["number_of_cells"] + 1
+
+    # plots.plot_foil(canopy, number_of_sections, surface="airfoil", flatten=False)
+
+    # plots.plot_foil(canopy, 131, surface="chord", flatten=False)
+    # plots.plot_foil(canopy, 131, surface="camber", flatten=False)
+    
+    # plots.plot_foil(canopy, number_of_sections, surface="airfoil", flatten=True)
+    # plots.plot_foil(canopy, 71, surface="chord", flatten=True)
+    # plots.plot_foil(canopy, 71, surface="camber", flatten=True)
+    
+    # plots.plot_foil_topdown(canopy, number_of_sections) # Compare to Line Plan
+
+    # plots.plot_foil_topdown(canopy, number_of_sections, flatten=True)
+
+    # Plot a braking wing
+    s = np.linspace(-1, 1, 131)  # Inflated plots
+    ai = wing.lines.delta_d(s, 0.5, 1) / wing.canopy.chord_length(s)
+    # plots.plot_foil(canopy, s, ai=ai, surface="airfoil", flatten=False)
+
+    # -----------------------------------------------------------------------
+    # Model diagnostics
+
+    if verbose:
+        print("Canopy geometry:           [Target]")
+        print(f"  flattened span: {canopy.b_flat:>6.3f}   [{specs['b_flat']:>6.3f}]")
+        print(f"  flattened area: {canopy.S_flat:>6.3f}   [{specs['S_flat']:>6.3f}]")
+        print(f"  flattened AR:   {canopy.AR_flat:>6.3f}   [{specs['AR_flat']:>6.3f}]")
+        # print(f"  planform flat SMC   {canopy.SMC:>6.3f}")
+        # print(f"  planform flat MAC:  {canopy.MAC:>6.3f}")
+        print(f"  projected span: {canopy.b:>6.3f}   [{specs['b']:>6.3f}]")
+        print(f"  projected area: {canopy.S:>6.3f}   [{specs['S']:>6.3f}]")
+        print(f"  projected AR:   {canopy.AR:>6.3f}   [{specs['AR']:>6.3f}]")
+        print()
+
+        # Reminder that I'm not accounting for mass from things like the lines,
+        # internal vribs, internal horizontal straps, caribiners, etc.
+        r_RM2LE = wing.r_RM2LE(delta_a=0)
+        wmp = wing.mass_properties(rho_air=1.225, r_R2LE=r_RM2LE)
+        print("Wing inertia:              [Target]")
+        print(f"  solid mass:     {wmp['m_s']:>6.3f}   [{specs['m_s']:>6.3f}]")
+        print()
+
+        print(f"Maximum brake length (kappa_b): {wing.lines.kappa_b}")
+
+        print("Finished building the glider.\n")
+
+    return wing


### PR DESCRIPTION
## About
This adds Skywalk Mescal 6 glider to the extras/wings package and the simulation script to draw polar curves. Data was obtained from: https://skywalk.info/project/mescal/

By the way, very cool project! And thanks for a thorough documentation, paper and open-sourcing the codebase! :parachute: 

## Note
* Certain parameters are quite hard to guess / empirical. And most were copied from Nivuk hook 3 :cry: 
* Only XS size has been added, and details on other parameters in the model need to be tuned

### Comparison of flattened model with line chart of datasheet
![Screenshot from 2023-01-15 14-23-32](https://user-images.githubusercontent.com/23277211/212544492-45350e09-9669-42b7-9e0f-992a6fc00019.png)

* Seems like the cell sizes are really big in the middle & smaller on the outside, so the discrepancy in cell division lines arises. In the actual simulated model, however, do we consider the differences in cell opening lengths in spanwise direction?
* The projected map differs slightly, especially how the outermost chord diminishes much smoothly in actual glider, compared to the simulated one. Is this also a common trait with Nivuk glider? Or does this indicate that I didn't set the model correctly?

## Questions
How would we accurately measure the following?:
1. `kappa_C`: For Mescal 6, the lineplan shows that C-risers are not connected just spanwise, but also cordwise. In this case, which value should be chosen for the C risers's attach point along the chord?
2. `s_delta_start/stop0/1`: These are really tricky, are the videos the only way to measure this?
3. `kappa_z`: I added the 'middle line length excluding length of risers' from the technical data, is it accurate to assume that the tip of the riser is matching the Riser-Midpoint?
4. `kappa_x`: We can't really tell what this value should be (chordwise offset from leading edge to pilot's position hung under the glider. How did you initially come up with the number `0.45 * Chord_root`?
5. `kappa_b`: I initially thought this should be the brake-line range (specified also in Technical data), but after reading the paper it seems like this range can't be directly translated into the `kappa_b` (actual movement of TE) that we desire. But, is there some way to calculate this?
6. `SimpleFoil/aerodynamics_config`: We use `v_ref_mag` of 10, and `alpha_ref` of 5. I didn't read in detail, but how would changing these values affect the final aerodynamic calculation of the glider? Are these values from some reference?